### PR TITLE
fix: grammar and settle on one shell

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -281,7 +281,7 @@ Run the below command and click `ctrl` + `c` to destroy the instance
 
 ### List instances
 
-A list of instance can be retrieved using the `list.sh` script.
+A list of instances can be retrieved using the `list.sh` script.
 
 ```sh
 ./list.sh
@@ -296,7 +296,7 @@ list of instances and their groups. In which case the below command might prove 
 
 ### Create an instance
 
-An instances can be created using the `dhis2-create.sh` script.
+An instance can be created using the `dhis2-create.sh` script.
 
 Run the below command to create an instance with the name "test-instance" belonging to the group called "test-group"
 
@@ -306,7 +306,7 @@ Run the below command to create an instance with the name "test-instance" belong
 
 ### Deploy instance
 
-An instances can be deployed using the `dhis2-deploy.sh` script.
+An instance can be deployed using the `dhis2-deploy.sh` script.
 
 Run the below command to deploy an instance with the name "test-instance" belonging to the group called "test-group"
 

--- a/api/README.md
+++ b/api/README.md
@@ -255,7 +255,7 @@ Configure a `.env` file matching what's defined for the user service.
 Export the above file and sign in to the service.
 
 ```sh
-export ACCESS_TOKEN="" && eval (./login.sh) && echo $ACCESS_TOKEN
+export ACCESS_TOKEN="" && eval $(./login.sh) && echo $ACCESS_TOKEN
 ```
 
 Assuming the above prints an access token the login was successful.

--- a/api/README.md
+++ b/api/README.md
@@ -92,7 +92,7 @@ The intention of the scripts is to provide an example of each endpoint.
 ## Environment
 
 Each service operates independently and serves its own set of end points. However, the services deployed in the "dev"
-environment are all access via the gateway.
+environment are all accessed via the gateway.
 
 Several services, including the gateway itself, depend on the user services so let's focus on that.
 


### PR DESCRIPTION
* grammar
* write for one shell type as other commands use `$()` not fish style `()`
